### PR TITLE
update runtime and use baseapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .directory
 *.flatpak
 .flatpak-builder
-build-dir/
-myrepo/
+builddir/
+repo/

--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,26 @@
 
 all: generate-dependencies build bundle install
 
+ID := io.github.voxelcubes.deepqt
+
+
 generate-dependencies:
-	python flatpak-pip-generator-fix --runtime='org.freedesktop.Sdk//22.08' --yaml --output pypi-dependencies --requirements-file='requirements.txt'
+	python flatpak-pip-generator-fix --runtime='org.kde.Sdk//6.7' --yaml --output pypi-dependencies --requirements-file='requirements.txt'
 
-build:
-	flatpak-builder --repo=myrepo --force-clean build-dir io.github.voxelcubes.deepqt.yaml
-
-bundle:
-	flatpak build-bundle myrepo deepqt.flatpak io.github.voxelcubes.deepqt
-
-install:
-	flatpak install --user deepqt.flatpak
+build-install:
+	flatpak run org.flatpak.Builder --force-clean --sandbox --user --install --install-deps-from=flathub --ccache --mirror-screenshots-url=https://dl.flathub.org/repo/screenshots --repo=repo builddir $(ID).yaml
 
 run:
-	flatpak run io.github.voxelcubes.deepqt
+	flatpak run $(ID)
+
+lint:
+	flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest $(ID).yaml
+	flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo repo
 
 clean:
-	rm -rf build-dir myrepo deepqt.flatpak .flatpak-builder
+	rm -rf builddir repo deepqt.flatpak .flatpak-builder
+
+introspect:
+	flatpak run --command=sh --devel $(ID)
+
+

--- a/io.github.voxelcubes.deepqt.yaml
+++ b/io.github.voxelcubes.deepqt.yaml
@@ -1,7 +1,9 @@
 app-id: io.github.voxelcubes.deepqt
 runtime: org.kde.Platform
-runtime-version: '5.15-22.08'
+runtime-version: '6.7'
 sdk: org.kde.Sdk
+base: io.qt.PySide.BaseApp
+base-version: 6.7
 command: deepqt
 finish-args:
   - --share=ipc
@@ -29,3 +31,5 @@ modules:
       - install -Dm644 media/deepqt.png /app/share/icons/hicolor/256x256/apps/io.github.voxelcubes.deepqt.png
       - install -Dm644 flatpak/io.github.voxelcubes.deepqt.appdata.xml /app/share/metainfo/io.github.voxelcubes.deepqt.appdata.xml
       - desktop-file-edit --set-key="Icon" --set-value=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh

--- a/pypi-dependencies.yaml
+++ b/pypi-dependencies.yaml
@@ -1,4 +1,4 @@
-# Generated with flatpak-pip-generator --runtime=org.freedesktop.Sdk//22.08 --yaml --output pypi-dependencies --requirements-file=requirements.txt
+# Generated with flatpak-pip-generator --runtime=org.kde.Sdk//6.7 --yaml --output pypi-dependencies --requirements-file=requirements.txt
 build-commands: []
 buildsystem: simple
 modules:
@@ -9,23 +9,23 @@ modules:
         --prefix=${FLATPAK_DEST} "deepl" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl
-        sha256: 4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
+        url: https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl
+        sha256: 1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56
       - type: file
-        url: https://files.pythonhosted.org/packages/cc/f6/21a66e524658bd1dd7b89ac9d1ee8f7823f2d9701a2fbc458ab9ede53c63/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-        sha256: 75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795
+        url: https://files.pythonhosted.org/packages/88/83/489e9504711fa05d8dde1574996408026bdbdbd938f23be67deebb5eca92/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256: fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00
       - type: file
-        url: https://files.pythonhosted.org/packages/90/00/eb918802fbf221456e817768a190c66b09ae607ccaa038c640a009e716e4/deepl-1.14.0-py3-none-any.whl
-        sha256: 7203b495d3356559b433544385d58c50257ad48035fc490730258b76fedd82f6
+        url: https://files.pythonhosted.org/packages/f7/24/48054f6808a5586f7195c2c26fef52b598c0ebf37542ee46dd9da72fe9e1/deepl-1.20.0-py3-none-any.whl
+        sha256: 69f93a26d70bff6e2204a71f2e601c4b826cbad1ff6f0e3065cbf5d17a0662d9
       - type: file
-        url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
-        sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+        url: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
+        sha256: 946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
       - type: file
-        url: https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl
-        sha256: 64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa
+        url: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
+        sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
       - type: file
-        url: https://files.pythonhosted.org/packages/7b/f5/890a0baca17a61c1f92f72b81d3c31523c99bec609e60c292ea55b387ae8/urllib3-1.26.15-py2.py3-none-any.whl
-        sha256: aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42
+        url: https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl
+        sha256: 1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df
   - name: python3-logzero
     buildsystem: simple
     build-commands:
@@ -35,24 +35,6 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/b3/68/aa714515d65090fcbcc9a1f3debd5a644b14aad11e59238f42f00bd4b298/logzero-1.7.0-py2.py3-none-any.whl
         sha256: 23eb1f717a2736f9ab91ca0d43160fd2c996ad49ae6bad34652d47aba908769d
-  - name: python3-PySide6
-    buildsystem: simple
-    build-commands:
-      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "PySide6" --no-build-isolation
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/61/c1/37fabc94f958a03a605755ee1298d9f7d9f5d121f3d1ea2d480f79fc3d6c/PySide6-6.5.0-cp37-abi3-manylinux_2_28_x86_64.whl
-        sha256: 5102c57841b15facb0aeca1f23d689ebc528a609bf5fb907f1ef2747f6415001
-      - type: file
-        url: https://files.pythonhosted.org/packages/96/df/28d29fe32fc0f28f95d8b1e209c89f3cbbc7f3b68901368ffbe4f49e38c1/PySide6_Addons-6.5.0-cp37-abi3-manylinux_2_28_x86_64.whl
-        sha256: 29551ca63a1cbc0fcd17fa9e477282857e2c66c3a55fdb9754b75519d5adf89a
-      - type: file
-        url: https://files.pythonhosted.org/packages/9d/cd/da6815d1654bf5daf4cd7a0f0dbb316413f29f9ae62d508cebcab4309094/PySide6_Essentials-6.5.0-cp37-abi3-manylinux_2_28_x86_64.whl
-        sha256: f00d4f10758cdc3f49f94465ead788ad294dac7d9cc5e1cc0610e97c2bdfc8d7
-      - type: file
-        url: https://files.pythonhosted.org/packages/05/f8/743a0a67ab81665788180689e0eebd32ac521c56ad003386b3de36f41e4e/shiboken6-6.5.0-cp37-abi3-manylinux_2_28_x86_64.whl
-        sha256: 46ff977f96c9d45dba3c3a313628356fd40e4423bb65bf2d9870b73396fad8be
   - name: python3-xdg
     buildsystem: simple
     build-commands:
@@ -68,23 +50,20 @@ modules:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
         --prefix=${FLATPAK_DEST} "pyexcel" --no-build-isolation
     sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/74/8f/8fc49109009e8d2169d94d72e6b1f4cd45c13d147ba7d6170fb41f22b08f/chardet-5.1.0-py3-none-any.whl
-        sha256: 362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9
       - &id001
         type: file
         url: https://files.pythonhosted.org/packages/10/76/b0967eae4af4b7ea22e8b8ece6f7655fb6a3f4f49428f41910f53a552e1e/lml-0.1.0-py2.py3-none-any.whl
         sha256: ec06e850019942a485639c8c2a26bdb99eae24505bee7492b649df98a0bed101
       - type: file
-        url: https://files.pythonhosted.org/packages/8b/cc/ca982e73be7f817511b11b5c63c8420bf51cb54474d1f3ffab18201c2d3e/pyexcel-0.7.0-py2.py3-none-any.whl
-        sha256: ddc6904512bfa2ecda509fb3b58229bb30db14498632fd9e7a5ba7bbfb02ed1b
+        url: https://files.pythonhosted.org/packages/a9/39/72a95e9327fe27d0597adce3c317d23e45ca899df335313e6ba20464b8fc/pyexcel-0.7.1-py2.py3-none-any.whl
+        sha256: 3306e66e24ef24e34399d329a508d669884a3577a557679c94edda9efc88b834
       - &id002
         type: file
-        url: https://files.pythonhosted.org/packages/4f/e1/68ec0cfd9c2b165eb199e07aaaaacde5a92d4a5fd986560027037c9491a5/pyexcel_io-0.6.6-py2.py3-none-any.whl
-        sha256: 19ff1d599a8a6c0982e4181ef86aa50e1f8d231410fa7e0e204d62e37551c1d6
+        url: https://files.pythonhosted.org/packages/7d/95/44376fb9c5a8200167fc7beac640be3522f85c07297a810865c5ad3fe440/pyexcel_io-0.6.7-py2.py3-none-any.whl
+        sha256: add9f3c1489070ab0a3226bab7d23d4b84a364f5b44f3a14e2ce785ede88fcb3
       - type: file
-        url: https://files.pythonhosted.org/packages/ba/a7/2c12b543f853dae886286b824200eb9d7cd2466e3d14eff1799fbe8223b9/texttable-1.6.7-py2.py3-none-any.whl
-        sha256: b7b68139aa8a6339d2c320ca8b1dc42d13a7831a346b446cb9eb385f0c76310c
+        url: https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl
+        sha256: 72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917
   - name: python3-pyexcel-odsr
     buildsystem: simple
     build-commands:
@@ -94,8 +73,8 @@ modules:
       - *id001
       - &id003
         type: file
-        url: https://files.pythonhosted.org/packages/89/9c/be3ebeb6053c6625c0497f282e0d8acc36c309212d47201e9cb1198ffb54/lxml-4.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl
-        sha256: 1ab8f1f932e8f82355e75dda5413a57612c6ea448069d4fb2e217e9a4bed13d4
+        url: https://files.pythonhosted.org/packages/42/07/b29571a58a3a80681722ea8ed0ba569211d9bb8531ad49b5cacf6d409185/lxml-5.3.0-cp311-cp311-manylinux_2_28_x86_64.whl
+        sha256: eec1bb8cdbba2925bedc887bc0609a80e599c75b12d87ae42ac23fd199445654
       - *id002
       - type: file
         url: https://files.pythonhosted.org/packages/60/cc/447b38791bec0653b17c9931f8b68617cdc16528c18c53841b606b1686b7/pyexcel_odsr-0.6.0-py2.py3-none-any.whl
@@ -124,12 +103,12 @@ modules:
         --prefix=${FLATPAK_DEST} "pyexcel-xlsx" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/96/c2/3dd434b0108730014f1b96fd286040dc3bcb70066346f7e01ec2ac95865f/et_xmlfile-1.1.0-py3-none-any.whl
-        sha256: a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada
+        url: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+        sha256: 7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa
       - *id001
       - type: file
-        url: https://files.pythonhosted.org/packages/6a/94/a59521de836ef0da54aaf50da6c4da8fb4072fb3053fa71f052fd9399e7a/openpyxl-3.1.2-py2.py3-none-any.whl
-        sha256: f91456ead12ab3c6c2e9491cf33ba6d08357d802192379bb482f1033ade496f5
+        url: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
+        sha256: 5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2
       - *id002
       - type: file
         url: https://files.pythonhosted.org/packages/6e/25/80131799ac6ab63c01749bb0d34664ebfd8478e51fbdda0dcef6a3556162/pyexcel_xlsx-0.6.0-py2.py3-none-any.whl
@@ -159,11 +138,11 @@ modules:
         --prefix=${FLATPAK_DEST} "beautifulsoup4" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/57/f4/a69c20ee4f660081a7dedb1ac57f29be9378e04edfcb90c526b923d4bebc/beautifulsoup4-4.12.2-py3-none-any.whl
-        sha256: bd2520ca0d9d7d12694a53d44ac482d181b4ec1888909b035a3dbf40d0f57d4a
+        url: https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3-py3-none-any.whl
+        sha256: b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
       - type: file
-        url: https://files.pythonhosted.org/packages/49/37/673d6490efc51ec46d198c75903d99de59baffdd47aea3d071b80a9e4e89/soupsieve-2.4.1-py3-none-any.whl
-        sha256: 1c1bfee6819544a3447586c889157365a27e10d88cde3ad3da0cf0ddf646feb8
+        url: https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl
+        sha256: e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9
   - name: python3-minify_html
     buildsystem: simple
     build-commands:
@@ -171,8 +150,8 @@ modules:
         --prefix=${FLATPAK_DEST} "minify_html" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/35/ad/461da8c4a2c83e07956fcd24e825c19cb6bc009272281b5c9765a1ed6295/minify_html-0.10.8-cp310-cp310-manylinux_2_27_x86_64.whl
-        sha256: 282f3439eb0cec40d3f502350a1e31e2c8d4e4d789d10b900f7eb2e84a318c6c
+        url: https://files.pythonhosted.org/packages/a0/e2/ed7e62f62a54774c411a0e28ef67a7d1ccb84ab1a933f6b59362c83d78c1/minify_html-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256: d4c4ae3909e2896c865ebaa3a96939191f904dd337a87d7594130f3dfca55510
   - name: python3-lxml
     buildsystem: simple
     build-commands:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 deepl
 logzero
-PySide6
 xdg
 pyexcel
 pyexcel-odsr


### PR DESCRIPTION
This is a bit more extensive than what @rawar089 proposed, as I'm drawing from my improvements for the panel cleaner flatpak. This will now use the qt baseapp, which makes it look native on KDE desktops, and hopefully works better for others as well. More extensive fixes will have to wait until I revamp the app. The updated dependencies should also fix an issue with deepl.

Using Qt6.7 for the baseapp since that was the version the assets were compiled for.